### PR TITLE
Add offset, mb_offset and mb_length to emoji detect response.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/Emoji.php
+++ b/src/Emoji.php
@@ -19,8 +19,12 @@ function detect_emoji($string) {
   if(!isset($regexp))
     $regexp = _load_regexp();
 
-  if(preg_match_all($regexp, $string, $matches)) {
-    foreach($matches[0] as $ch) {
+  if(preg_match_all($regexp, $string, $matches, PREG_OFFSET_CAPTURE)) {
+    $emojisLength = 0;
+    foreach($matches[0] as $match) {
+      $ch = $match[0];
+      $offset = $match[1] - $emojisLength;
+      $emojisLength += (strlen($ch) - 1);
       $points = array();
       for($i=0; $i<mb_strlen($ch); $i++) {
         $points[] = strtoupper(dechex(uniord(mb_substr($ch, $i, 1))));
@@ -53,6 +57,7 @@ function detect_emoji($string) {
         'points_hex' => $points,
         'hex_str' => $hexstr,
         'skin_tone' => $skin_tone,
+        'offset' => $offset,
       );
     }
   }

--- a/src/Emoji.php
+++ b/src/Emoji.php
@@ -21,12 +21,16 @@ function detect_emoji($string) {
 
   if(preg_match_all($regexp, $string, $matches, PREG_OFFSET_CAPTURE)) {
     $emojisLength = 0;
+    $lastMbOffset = 0;
     foreach($matches[0] as $match) {
       $ch = $match[0];
       $offset = $match[1] - $emojisLength;
+      $mbOffset = mb_strpos($string, $ch, $lastMbOffset);
+      $mbLength = mb_strlen($ch);
+      $lastMbOffset = $offset + $mbLength;
       $emojisLength += (strlen($ch) - 1);
       $points = array();
-      for($i=0; $i<mb_strlen($ch); $i++) {
+      for($i=0; $i<$mbLength; $i++) {
         $points[] = strtoupper(dechex(uniord(mb_substr($ch, $i, 1))));
       }
       $hexstr = implode('-', $points);
@@ -58,6 +62,8 @@ function detect_emoji($string) {
         'hex_str' => $hexstr,
         'skin_tone' => $skin_tone,
         'offset' => $offset,
+        'mb_offset' => $mbOffset,
+        'mb_length' => $mbLength
       );
     }
   }

--- a/tests/EmojiDetectTest.php
+++ b/tests/EmojiDetectTest.php
@@ -149,4 +149,15 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     }
   }
 
+  public function testDetectAndReplace()
+  {
+    $string = 'I like 🌮 and 🌯';
+    while (sizeof($emojis = Emoji\detect_emoji($string)) > 0) {
+      $offset = $emojis[0]['mb_offset'];
+      $length = $emojis[0]['mb_length'];
+      $string = mb_substr($string, 0, $offset).$emojis[0]['short_name'].mb_substr($string, $offset + $length);
+    }
+    $this->assertSame('I like taco and burrito', $string);
+  }
+
 }

--- a/tests/EmojiDetectTest.php
+++ b/tests/EmojiDetectTest.php
@@ -9,6 +9,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $this->assertSame('😻', $emoji[0]['emoji']);
     $this->assertSame('heart_eyes_cat', $emoji[0]['short_name']);
     $this->assertSame('1F63B', $emoji[0]['hex_str']);
+    $this->assertSame(0, $emoji[0]['offset']);
   }
 
   public function testDetectEvenSimplerEmoji() {
@@ -18,6 +19,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $this->assertSame('❤️', $emoji[0]['emoji']);
     $this->assertSame('heart', $emoji[0]['short_name']);
     $this->assertSame('2764-FE0F', $emoji[0]['hex_str']);
+    $this->assertSame(0, $emoji[0]['offset']);
   }
 
   public function testDetectEmojiWithZJW() {
@@ -26,6 +28,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $this->assertCount(1, $emoji);
     $this->assertSame('man-woman-boy-boy', $emoji[0]['short_name']);
     $this->assertSame('1F468-200D-1F469-200D-1F466-200D-1F466', $emoji[0]['hex_str']);
+    $this->assertSame(0, $emoji[0]['offset']);
   }
 
   public function testDetectEmojiWithZJW2() {
@@ -34,6 +37,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $this->assertCount(1, $emoji);
     $this->assertSame('woman-heart-woman', $emoji[0]['short_name']);
     $this->assertSame('1F469-200D-2764-FE0F-200D-1F469', $emoji[0]['hex_str']);
+    $this->assertSame(0, $emoji[0]['offset']);
   }
 
   public function testDetectEmojiWithSkinTone() {
@@ -44,6 +48,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $this->assertSame('+1', $emoji[0]['short_name']);
     $this->assertSame('1F44D-1F3FC', $emoji[0]['hex_str']);
     $this->assertSame('skin-tone-3', $emoji[0]['skin_tone']);
+    $this->assertSame(0, $emoji[0]['offset']);
   }
 
   public function testDetectMultipleEmoji() {
@@ -52,6 +57,8 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $this->assertCount(2, $emoji);
     $this->assertSame('woman', $emoji[0]['short_name']);
     $this->assertSame('heart', $emoji[1]['short_name']);
+    $this->assertSame(0, $emoji[0]['offset']);
+    $this->assertSame(1, $emoji[1]['offset']);
   }
 
   public function testDetectFlagEmoji() {
@@ -59,6 +66,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $emoji = Emoji\detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('flag-de', $emoji[0]['short_name']);
+    $this->assertSame(0, $emoji[0]['offset']);
   }
 
   public function testDetectSymbolWithModifier() {
@@ -66,6 +74,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $emoji = Emoji\detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('recycle', $emoji[0]['short_name']);
+    $this->assertSame(0, $emoji[0]['offset']);
   }
 
   public function testDetectCharacterSymbol() {
@@ -73,6 +82,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $emoji = Emoji\detect_emoji($string);
     $this->assertEquals(1, count($emoji));
     $this->assertEquals('tm', $emoji[0]['short_name']);
+    $this->assertSame(0, $emoji[0]['offset']);
   }
 
   public function testDetectEmojiWithZJW3() {
@@ -81,12 +91,13 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $this->assertCount(1, $emoji);
     $this->assertSame('rainbow-flag', $emoji[0]['short_name']);
     $this->assertSame('1F3F3-FE0F-200D-1F308', $emoji[0]['hex_str']);
+    $this->assertSame(0, $emoji[0]['offset']);
   }
 
   public function testDetectText() {
     $string = 'This has no emoji.';
     $emoji = Emoji\detect_emoji($string);
-    $this->assertCount(0, $emoji);  
+    $this->assertCount(0, $emoji);
   }
 
   public function testDetectInText() {
@@ -94,6 +105,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $emoji = Emoji\detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('tada', $emoji[0]['short_name']);
+    $this->assertSame(12, $emoji[0]['offset']);
   }
 
   public function testDetectGenderModifier() {
@@ -102,6 +114,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $emoji = Emoji\detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('female-guard', $emoji[0]['short_name']);
+    $this->assertSame(12, $emoji[0]['offset']);
   }
 
   public function testDetectGenderAndSkinToneModifier() {
@@ -110,6 +123,19 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     $emoji = Emoji\detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('female-guard', $emoji[0]['short_name']);
+    $this->assertSame(12, $emoji[0]['offset']);
+  }
+
+  public function testDetectOffset() {
+    $string = 'word 👩 word ❤️ word 💂 word 👨‍👩‍👦‍👦 word 👩‍❤️‍👩 word ♻️';
+    $emoji = Emoji\detect_emoji($string);
+    $this->assertCount(6, $emoji);
+    $this->assertSame(5, $emoji[0]['offset']);
+    $this->assertSame(12, $emoji[1]['offset']);
+    $this->assertSame(19, $emoji[2]['offset']);
+    $this->assertSame(26, $emoji[3]['offset']);
+    $this->assertSame(33, $emoji[4]['offset']);
+    $this->assertSame(40, $emoji[5]['offset']);
   }
 
 }

--- a/tests/EmojiDetectTest.php
+++ b/tests/EmojiDetectTest.php
@@ -127,15 +127,26 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
   }
 
   public function testDetectOffset() {
-    $string = 'word 👩 word ❤️ word 💂 word 👨‍👩‍👦‍👦 word 👩‍❤️‍👩 word ♻️';
+    $emojis = [
+        '👩',
+        '❤️',
+        '💂',
+        '👨‍👩‍👦‍👦',
+        '👩‍❤️‍👩',
+        '♻️'
+    ];
+    $separator = ' word ';
+    $string = implode($separator, $emojis);
     $emoji = Emoji\detect_emoji($string);
-    $this->assertCount(6, $emoji);
-    $this->assertSame(5, $emoji[0]['offset']);
-    $this->assertSame(12, $emoji[1]['offset']);
-    $this->assertSame(19, $emoji[2]['offset']);
-    $this->assertSame(26, $emoji[3]['offset']);
-    $this->assertSame(33, $emoji[4]['offset']);
-    $this->assertSame(40, $emoji[5]['offset']);
+    $this->assertCount(sizeof($emojis), $emoji);
+    $currentOffset = 0;
+    $currentMbOffset = 0;
+    foreach ($emojis as $index => $emoj) {
+        $this->assertSame($currentOffset, $emoji[$index]['offset']);
+        $this->assertSame($currentMbOffset, $emoji[$index]['mb_offset']);
+        $currentOffset += strlen($separator) + 1;
+        $currentMbOffset += strlen($separator) + $emoji[$index]['mb_length'];
+    }
   }
 
 }

--- a/tests/EmojiDetectTest.php
+++ b/tests/EmojiDetectTest.php
@@ -144,8 +144,8 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
     foreach ($emojis as $index => $emoj) {
         $this->assertSame($currentOffset, $emoji[$index]['offset']);
         $this->assertSame($currentMbOffset, $emoji[$index]['mb_offset']);
-        $currentOffset += strlen($separator) + 1;
-        $currentMbOffset += strlen($separator) + $emoji[$index]['mb_length'];
+        $currentOffset += mb_strlen($separator) + 1;
+        $currentMbOffset += mb_strlen($separator) + $emoji[$index]['mb_length'];
     }
   }
 

--- a/tests/EmojiSingleTest.php
+++ b/tests/EmojiSingleTest.php
@@ -6,12 +6,14 @@ class EmojiSingleTest extends \PHPUnit\Framework\TestCase {
     $string = '😻';
     $emoji = Emoji\is_single_emoji($string);
     $this->assertSame($string, $emoji['emoji']);
+    $this->assertSame(0, $emoji['offset']);
   }
 
   public function testSingleCompositeEmoji() {
     $string = '👨‍👩‍👦‍👦';
     $emoji = Emoji\is_single_emoji($string);
     $this->assertSame($string, $emoji['emoji']);
+    $this->assertSame(0, $emoji['offset']);
   }
 
   public function testMultipleEmoji() {


### PR DESCRIPTION
I've added `offset`, `mb_offset` and `mb_length` to the emoji detection response so this library can be used to get the position of the emojis (and replace it).

`offset`: The position of the emoji in the string as if emojis had length of 1
`mb_offset`: The position of the emoji in the multi-bytes string
`mb_length`: The length of the emoji

Example: Replace all emojis with their short_name
```php
$string = 'I like 🌮and 🌯';
while (sizeof($emojis = Emoji\detect_emoji($string)) > 0) {
    $offset = $emojis[0]['mb_offset'];
    $length = $emojis[0]['mb_length'];
    $string = mb_substr($string, 0, $offset).$emojis[0]['short_name'].mb_substr($string, $offset + $length);
}
// $string = 'I like taco and burrito';
```