### PR TITLE
Test enhancementand drop old php-5.x versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,7 @@
 language: php
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
-  - nightly
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
+  - 7.3
+  - 7.4
 before_script: composer install
 script: php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,12 @@
     ]
   },
   "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
-    "php": ">=5.3",
+    "php": ">=7.2",
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8"
+    "phpunit/phpunit": "^8.5"
   }
 }


### PR DESCRIPTION
# Changed log

- Since the `PHP-7.2` version is active currently on official PHP team, it should let this project require `php-7.2` version at least.
- Since requiring `PHP` version is `7.2` at least, it should let package upgrade `PHPUnit` version to `^8.5`.