### PR TITLE
Improve assertions and test class namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,11 @@
       "src/Emoji.php"
     ]
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Emoji\\": "tests"
+    }
+  },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {

--- a/tests/EmojiDetectTest.php
+++ b/tests/EmojiDetectTest.php
@@ -1,10 +1,11 @@
 <?php
+namespace Emoji;
 
 class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
 
   public function testDetectSimpleEmoji() {
     $string = '😻';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('😻', $emoji[0]['emoji']);
     $this->assertSame('heart_eyes_cat', $emoji[0]['short_name']);
@@ -13,7 +14,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
 
   public function testDetectEvenSimplerEmoji() {
     $string = '❤️';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('❤️', $emoji[0]['emoji']);
     $this->assertSame('heart', $emoji[0]['short_name']);
@@ -22,7 +23,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
 
   public function testDetectEmojiWithZJW() {
     $string = '👨‍👩‍👦‍👦';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('man-woman-boy-boy', $emoji[0]['short_name']);
     $this->assertSame('1F468-200D-1F469-200D-1F466-200D-1F466', $emoji[0]['hex_str']);
@@ -30,7 +31,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
 
   public function testDetectEmojiWithZJW2() {
     $string = '👩‍❤️‍👩';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('woman-heart-woman', $emoji[0]['short_name']);
     $this->assertSame('1F469-200D-2764-FE0F-200D-1F469', $emoji[0]['hex_str']);
@@ -38,7 +39,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
 
   public function testDetectEmojiWithSkinTone() {
     $string = '👍🏼';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('👍🏼', $emoji[0]['emoji']);
     $this->assertSame('+1', $emoji[0]['short_name']);
@@ -48,7 +49,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
 
   public function testDetectMultipleEmoji() {
     $string = '👩❤️';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(2, $emoji);
     $this->assertSame('woman', $emoji[0]['short_name']);
     $this->assertSame('heart', $emoji[1]['short_name']);
@@ -56,28 +57,28 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
 
   public function testDetectFlagEmoji() {
     $string = '🇩🇪';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('flag-de', $emoji[0]['short_name']);
   }
 
   public function testDetectSymbolWithModifier() {
     $string = '♻️';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('recycle', $emoji[0]['short_name']);
   }
 
   public function testDetectCharacterSymbol() {
     $string = '™️';
-    $emoji = Emoji\detect_emoji($string);
-    $this->assertEquals(1, count($emoji));
-    $this->assertEquals('tm', $emoji[0]['short_name']);
+    $emoji = detect_emoji($string);
+    $this->assertCount(1, $emoji);
+    $this->assertSame('tm', $emoji[0]['short_name']);
   }
 
   public function testDetectEmojiWithZJW3() {
     $string = '🏳️‍🌈';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('rainbow-flag', $emoji[0]['short_name']);
     $this->assertSame('1F3F3-FE0F-200D-1F308', $emoji[0]['hex_str']);
@@ -85,13 +86,13 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
 
   public function testDetectText() {
     $string = 'This has no emoji.';
-    $emoji = Emoji\detect_emoji($string);
-    $this->assertCount(0, $emoji);  
+    $emoji = detect_emoji($string);
+    $this->assertCount(0, $emoji);
   }
 
   public function testDetectInText() {
     $string = 'This has an 🎉 emoji.';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('tada', $emoji[0]['short_name']);
   }
@@ -99,7 +100,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
   public function testDetectGenderModifier() {
     // Added in June 2017 http://www.unicode.org/Public/emoji/5.0/emoji-test.txt
     $string = 'guardswoman 💂‍♀️';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('female-guard', $emoji[0]['short_name']);
   }
@@ -107,7 +108,7 @@ class EmojiDetectTest extends \PHPUnit\Framework\TestCase {
   public function testDetectGenderAndSkinToneModifier() {
     // Added in June 2017 http://www.unicode.org/Public/emoji/5.0/emoji-test.txt
     $string = 'guardswoman 💂🏼‍♀️';
-    $emoji = Emoji\detect_emoji($string);
+    $emoji = detect_emoji($string);
     $this->assertCount(1, $emoji);
     $this->assertSame('female-guard', $emoji[0]['short_name']);
   }

--- a/tests/EmojiSingleTest.php
+++ b/tests/EmojiSingleTest.php
@@ -1,28 +1,29 @@
 <?php
+namespace Emoji;
 
 class EmojiSingleTest extends \PHPUnit\Framework\TestCase {
 
   public function testSingleEmoji() {
     $string = '😻';
-    $emoji = Emoji\is_single_emoji($string);
+    $emoji = is_single_emoji($string);
     $this->assertSame($string, $emoji['emoji']);
   }
 
   public function testSingleCompositeEmoji() {
     $string = '👨‍👩‍👦‍👦';
-    $emoji = Emoji\is_single_emoji($string);
+    $emoji = is_single_emoji($string);
     $this->assertSame($string, $emoji['emoji']);
   }
 
   public function testMultipleEmoji() {
     $string = '😻🐈';
-    $emoji = Emoji\is_single_emoji($string);
+    $emoji = is_single_emoji($string);
     $this->assertFalse($emoji);
   }
 
   public function testSingleEmojiWithText() {
     $string = 'kitty 😻';
-    $emoji = Emoji\is_single_emoji($string);
+    $emoji = is_single_emoji($string);
     $this->assertFalse($emoji);
   }
 


### PR DESCRIPTION
# Changed log

- Adding the `Emoji` namespaces for all test classes on `tests` folder.
- Using the `assertSame` to make equals assertion strict.
- Using the `assertCount` to assert expected count is same as result count.