### PR TITLE
Added php-intl as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
   "prefer-stable": true,
   "require": {
     "php": ">=7.2",
-    "ext-mbstring": "*"
+    "ext-mbstring": "*",
+    "ext-intl": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5"


### PR DESCRIPTION
Hey @aaronpk,

I've added `php-intl` as a dependency to `composer.json` to avoid errors when `grapheme_ `functions are not available as was mentioned [here](https://github.com/aaronpk/emoji-detector-php/issues/19).